### PR TITLE
Remove Vercel cron schedules

### DIFF
--- a/vercel.json
+++ b/vercel.json
@@ -5,27 +5,5 @@
   "routes": [
     { "src": "/api-docs/(.*)", "dest": "/index.js" },
     { "src": "/(.*)", "dest": "/index.js" }
-  ],
-  "crons": [
-    {
-      "path": "/todos/process/reprioritize",
-      "schedule": "0 2 * * *"
-    },
-    {
-      "path": "/todos/process/new-day",
-      "schedule": "0 3 * * *"
-    },
-    {
-      "path": "/todos/process/new-day-focus",
-      "schedule": "0 4 * * *"
-    },
-    {
-      "path": "/todos/process/stale",
-      "schedule": "0 3 1 * *"
-    },
-    {
-      "path": "/todos/process/categorize",
-      "schedule": "0 5 * * 0"
-    }
   ]
 }


### PR DESCRIPTION
## Summary
- remove the Vercel cron schedule configuration to stop automated task execution

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f653031068832884a9ab9d1303642b