### PR TITLE
Add CI workflow for unit tests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,27 @@
+name: CI
+
+on:
+  pull_request:
+  push:
+    branches:
+      - main
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Check out repository
+        uses: actions/checkout@v4
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+          cache: 'npm'
+
+      - name: Install dependencies
+        run: npm install --include=dev
+
+      - name: Run unit tests
+        run: npm test -- --runInBand


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that installs dependencies with Node 22 and runs the Jest test suite on pushes to main and pull requests

## Testing
- Not run (CI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68f8eaecdfc8832890e53fbf30ab2f4f