### PR TITLE
Add unit tests for error handling and validation utilities

### DIFF
--- a/__tests__/AppError.test.js
+++ b/__tests__/AppError.test.js
@@ -1,0 +1,43 @@
+import {
+  AppError,
+  ValidationError,
+  NotFoundError,
+  AuthenticationError,
+  AuthorizationError,
+  ExternalServiceError,
+} from '../api/errors/AppError.js';
+
+describe('AppError hierarchy', () => {
+  it('sets default properties for AppError', () => {
+    const error = new AppError('Something failed');
+
+    expect(error.statusCode).toBe(500);
+    expect(error.code).toBe('INTERNAL_SERVER_ERROR');
+    expect(error.status).toBe('error');
+    expect(error.isOperational).toBe(true);
+  });
+
+  it('creates specialized error variants with expected codes', () => {
+    const validation = new ValidationError('Invalid');
+    const notFound = new NotFoundError('Missing');
+    const auth = new AuthenticationError('Auth');
+    const authorization = new AuthorizationError('Forbidden');
+    const external = new ExternalServiceError('External');
+
+    expect(validation).toMatchObject({
+      statusCode: 400,
+      code: 'VALIDATION_ERROR',
+      status: 'fail',
+    });
+    expect(notFound).toMatchObject({ statusCode: 404, code: 'NOT_FOUND' });
+    expect(auth).toMatchObject({ statusCode: 401, code: 'AUTHENTICATION_ERROR' });
+    expect(authorization).toMatchObject({
+      statusCode: 403,
+      code: 'AUTHORIZATION_ERROR',
+    });
+    expect(external).toMatchObject({
+      statusCode: 502,
+      code: 'EXTERNAL_SERVICE_ERROR',
+    });
+  });
+});

--- a/__tests__/auth.test.js
+++ b/__tests__/auth.test.js
@@ -1,0 +1,56 @@
+import { validateHash, validateCronJob } from '../_lib/auth.js';
+import { AuthenticationError } from '../api/errors/AppError.js';
+
+describe('validateHash', () => {
+  const originalEnv = process.env.HASH;
+
+  beforeEach(() => {
+    process.env.HASH = 'secret-hash';
+  });
+
+  afterAll(() => {
+    process.env.HASH = originalEnv;
+  });
+
+  it('throws AuthenticationError when hash is missing', () => {
+    expect(() => validateHash({ query: {} })).toThrow(AuthenticationError);
+  });
+
+  it('throws AuthenticationError when hash is incorrect', () => {
+    expect(() => validateHash({ query: { hash: 'wrong' } })).toThrow(
+      AuthenticationError,
+    );
+  });
+
+  it('does not throw when hash matches expected value', () => {
+    expect(() => validateHash({ query: { hash: 'secret-hash' } })).not.toThrow();
+  });
+});
+
+describe('validateCronJob', () => {
+  const originalEnv = process.env.CRON_SECRET;
+
+  beforeEach(() => {
+    process.env.CRON_SECRET = 'cron-secret';
+  });
+
+  afterAll(() => {
+    process.env.CRON_SECRET = originalEnv;
+  });
+
+  it('throws AuthenticationError when authorization header is missing', () => {
+    expect(() => validateCronJob({ headers: {} })).toThrow(AuthenticationError);
+  });
+
+  it('throws AuthenticationError when authorization header is incorrect', () => {
+    expect(() =>
+      validateCronJob({ headers: { authorization: 'Bearer wrong' } }),
+    ).toThrow(AuthenticationError);
+  });
+
+  it('does not throw when bearer token matches expected value', () => {
+    expect(() =>
+      validateCronJob({ headers: { authorization: 'Bearer cron-secret' } }),
+    ).not.toThrow();
+  });
+});

--- a/__tests__/errors.test.js
+++ b/__tests__/errors.test.js
@@ -1,0 +1,113 @@
+import { handleError, withErrorHandling } from '../_lib/errors.js';
+import { AppError } from '../api/errors/AppError.js';
+
+describe('handleError', () => {
+  let originalEnv;
+  let res;
+  let statusMock;
+  let jsonMock;
+
+  beforeEach(() => {
+    originalEnv = process.env.NODE_ENV;
+    jsonMock = jest.fn();
+    statusMock = jest.fn().mockReturnValue({ json: jsonMock });
+    res = {
+      status: statusMock,
+    };
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalEnv;
+    jest.restoreAllMocks();
+  });
+
+  it('returns detailed response in development mode', () => {
+    process.env.NODE_ENV = 'development';
+    const error = new AppError('fail', 400, 'VALIDATION_ERROR');
+
+    handleError(error, res);
+
+    expect(statusMock).toHaveBeenCalledWith(400);
+    expect(jsonMock).toHaveBeenCalledWith(
+      expect.objectContaining({
+        status: 'fail',
+        message: 'fail',
+      }),
+    );
+  });
+
+  it('returns operational error response in production mode', () => {
+    process.env.NODE_ENV = 'production';
+    const error = new AppError('not found', 404, 'NOT_FOUND');
+
+    handleError(error, res);
+
+    expect(statusMock).toHaveBeenCalledWith(404);
+    expect(jsonMock).toHaveBeenCalledWith({
+      status: 'fail',
+      code: 'NOT_FOUND',
+      message: 'not found',
+    });
+  });
+
+  it('returns generic response for unexpected errors', () => {
+    process.env.NODE_ENV = 'production';
+    const error = new Error('boom');
+
+    handleError(error, res);
+
+    expect(console.error).toHaveBeenCalled();
+    expect(statusMock).toHaveBeenCalledWith(500);
+    expect(jsonMock).toHaveBeenCalledWith({
+      status: 'error',
+      code: 'INTERNAL_SERVER_ERROR',
+      message: 'Something went wrong!',
+    });
+  });
+});
+
+describe('withErrorHandling', () => {
+  let originalEnv;
+  let res;
+  let statusMock;
+  let jsonMock;
+
+  beforeEach(() => {
+    originalEnv = process.env.NODE_ENV;
+    process.env.NODE_ENV = 'production';
+    jsonMock = jest.fn();
+    statusMock = jest.fn().mockReturnValue({ json: jsonMock });
+    res = { status: statusMock };
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    process.env.NODE_ENV = originalEnv;
+    jest.restoreAllMocks();
+  });
+
+  it('executes handler successfully when no error is thrown', async () => {
+    const handler = jest.fn().mockResolvedValue(undefined);
+    const wrapped = withErrorHandling(handler);
+
+    await wrapped({}, res);
+
+    expect(handler).toHaveBeenCalled();
+    expect(statusMock).not.toHaveBeenCalled();
+  });
+
+  it('handles errors thrown by handler', async () => {
+    const handler = jest.fn().mockRejectedValue(new Error('fail'));
+    const wrapped = withErrorHandling(handler);
+
+    await wrapped({}, res);
+
+    expect(statusMock).toHaveBeenCalledWith(500);
+    expect(jsonMock).toHaveBeenCalledWith({
+      status: 'error',
+      code: 'INTERNAL_SERVER_ERROR',
+      message: 'Something went wrong!',
+    });
+  });
+});

--- a/__tests__/validation.test.js
+++ b/__tests__/validation.test.js
@@ -1,0 +1,141 @@
+import {
+  validateEnvVariables,
+  validateAuthHash,
+  validateBearerToken,
+  validatePagination,
+  validatePriority,
+  validateProjectId,
+  sanitizeString,
+  validateRequiredFields,
+} from '../api/middleware/validation.js';
+import { ValidationError } from '../api/errors/AppError.js';
+
+describe('validateEnvVariables', () => {
+  const originalToken = process.env.TODOIST_TOKEN;
+  const originalKey = process.env.OPENAI_KEY;
+
+  afterEach(() => {
+    if (originalToken === undefined) {
+      delete process.env.TODOIST_TOKEN;
+    } else {
+      process.env.TODOIST_TOKEN = originalToken;
+    }
+
+    if (originalKey === undefined) {
+      delete process.env.OPENAI_KEY;
+    } else {
+      process.env.OPENAI_KEY = originalKey;
+    }
+  });
+
+  it('throws when required environment variables are missing', () => {
+    delete process.env.TODOIST_TOKEN;
+    delete process.env.OPENAI_KEY;
+
+    expect(() => validateEnvVariables()).toThrow(ValidationError);
+  });
+
+  it('passes when required environment variables are present', () => {
+    process.env.TODOIST_TOKEN = 'token';
+    process.env.OPENAI_KEY = 'key';
+
+    expect(() => validateEnvVariables()).not.toThrow();
+  });
+});
+
+describe('validateAuthHash', () => {
+  it('throws for invalid hash values', () => {
+    expect(() => validateAuthHash('')).toThrow(ValidationError);
+    expect(() => validateAuthHash('short')).toThrow(ValidationError);
+  });
+
+  it('does not throw for valid hash', () => {
+    expect(() => validateAuthHash('abcdefgh')).not.toThrow();
+  });
+});
+
+describe('validateBearerToken', () => {
+  it('throws when token missing or not a string', () => {
+    expect(() => validateBearerToken('')).toThrow(ValidationError);
+    expect(() => validateBearerToken(null)).toThrow(ValidationError);
+  });
+
+  it("throws when token does not include 'Bearer' prefix", () => {
+    expect(() => validateBearerToken('token')).toThrow(ValidationError);
+  });
+
+  it('passes for valid bearer token', () => {
+    expect(() => validateBearerToken('Bearer token')).not.toThrow();
+  });
+});
+
+describe('validatePagination', () => {
+  it('returns defaults when parameters are missing', () => {
+    expect(validatePagination()).toEqual({ limit: 50, offset: 0 });
+  });
+
+  it('throws when limit is out of range', () => {
+    expect(() => validatePagination({ limit: 0 })).toThrow(ValidationError);
+    expect(() => validatePagination({ limit: 101 })).toThrow(ValidationError);
+  });
+
+  it('throws when offset is negative', () => {
+    expect(() => validatePagination({ offset: -1 })).toThrow(ValidationError);
+  });
+
+  it('parses valid parameters correctly', () => {
+    expect(validatePagination({ limit: '20', offset: '5' })).toEqual({
+      limit: 20,
+      offset: 5,
+    });
+  });
+});
+
+describe('validatePriority', () => {
+  it('throws when priority is outside valid range', () => {
+    expect(() => validatePriority(0)).toThrow(ValidationError);
+    expect(() => validatePriority(5)).toThrow(ValidationError);
+  });
+
+  it('returns parsed priority for valid values', () => {
+    expect(validatePriority('4')).toBe(4);
+  });
+});
+
+describe('validateProjectId', () => {
+  it('throws when project id is invalid', () => {
+    expect(() => validateProjectId('')).toThrow(ValidationError);
+    expect(() => validateProjectId('abc123')).toThrow(ValidationError);
+  });
+
+  it('returns project id when valid', () => {
+    expect(validateProjectId('12345')).toBe('12345');
+  });
+});
+
+describe('sanitizeString', () => {
+  it('returns empty string for non-string input', () => {
+    expect(sanitizeString(null)).toBe('');
+  });
+
+  it('trims, limits length, and removes dangerous characters', () => {
+    const result = sanitizeString('   <script>alert(1)</script>   ', 10);
+    expect(result).toBe('scriptal');
+  });
+});
+
+describe('validateRequiredFields', () => {
+  it('throws when body is not an object', () => {
+    expect(() => validateRequiredFields(null, ['id'])).toThrow(ValidationError);
+  });
+
+  it('throws when required fields are missing', () => {
+    expect(() => validateRequiredFields({ id: 1 }, ['id', 'name'])).toThrow(
+      ValidationError,
+    );
+  });
+
+  it('passes when all required fields are present', () => {
+    expect(() => validateRequiredFields({ id: 1, name: 'Task' }, ['id', 'name'])).not.toThrow();
+  });
+});

--- a/api/middleware/validation.js
+++ b/api/middleware/validation.js
@@ -1,4 +1,4 @@
-import { ValidationError } from "../errors/AppError";
+import { ValidationError } from "../errors/AppError.js";
 
 /**
  * Validates that required environment variables are set

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,6 +1,5 @@
 module.exports = {
   testEnvironment: 'node',
   transform: {},
-  extensionsToTreatAsEsm: ['.js'],
   moduleFileExtensions: ['js', 'json'],
 };

--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,0 +1,6 @@
+module.exports = {
+  testEnvironment: 'node',
+  transform: {},
+  extensionsToTreatAsEsm: ['.js'],
+  moduleFileExtensions: ['js', 'json'],
+};


### PR DESCRIPTION
## Summary
- add a Jest configuration compatible with the repository's ESM modules
- add unit tests that exercise authentication helpers, error handling utilities, and validation middleware
- fix the validation middleware import so it resolves the AppError module correctly

## Testing
- npm test *(fails: Jest package is unavailable because dependencies cannot be installed in the offline environment)*

------
https://chatgpt.com/codex/tasks/task_e_68f8ec59a810832898dace839c5fa461