### PR TITLE
Configure Jest for ESM test files

### DIFF
--- a/jest.config.cjs
+++ b/jest.config.cjs
@@ -1,5 +1,6 @@
 module.exports = {
   testEnvironment: 'node',
   transform: {},
+  extensionsToTreatAsEsm: ['.js'],
   moduleFileExtensions: ['js', 'json'],
 };


### PR DESCRIPTION
## Summary
- configure Jest to treat JavaScript files as ES modules so tests using `import` syntax load correctly

## Testing
- npm test -- --runInBand *(fails: Jest is not installed because npm install cannot fetch the `vercel` package)*

------
https://chatgpt.com/codex/tasks/task_e_68f8f0db29708328bb69e645d5782978